### PR TITLE
All reactions (not just reversible ones) have now forward_variable and r...

### DIFF
--- a/cameo/flux_analysis/analysis.py
+++ b/cameo/flux_analysis/analysis.py
@@ -60,9 +60,6 @@ def flux_variability_analysis(model, reactions=None, fraction_of_optimum=0., rem
     if reactions is None:
         reactions = model.reactions
     with TimeMachine() as tm:
-        if model.reversible_encoding == 'split':
-            tm(do=partial(setattr, model, 'reversible_encoding', 'unsplit'),
-               undo=partial(setattr, model, 'reversible_encoding', 'split'))
         if fraction_of_optimum > 0.:
             try:
                 obj_val = model.solve().f
@@ -117,9 +114,6 @@ def phenotypic_phase_plane(model, variables=[], objective=None, points=20, view=
     if view is None:
         view = config.default_view
     with TimeMachine() as tm:
-        if model.reversible_encoding == 'split':
-            tm(do=partial(setattr, model, 'reversible_encoding', 'unsplit'),
-               undo=partial(setattr, model, 'reversible_encoding', 'split'))
         if objective is not None:
             tm(do=partial(setattr, model, 'objective', objective),
                undo=partial(setattr, model, 'objective', model.objective))

--- a/cameo/flux_analysis/distance.py
+++ b/cameo/flux_analysis/distance.py
@@ -22,7 +22,6 @@ from six import types
 
 from sympy import Add
 from sympy import Mul
-from sympy import RealNumber
 
 from cameo.core.result import FluxDistributionResult
 from cameo.core.solution import SolutionBase
@@ -180,65 +179,20 @@ class RegulatoryOnOffDistance(Distance):
 
     def _add_switch_constraint(self, reaction_id, flux_value, delta=0.03, epsilon=0.001):
         reaction = self.model.reactions.get_by_id(reaction_id)
-        var = self.model.solver.interface.Variable("y_" + reaction_id, type="binary")
-        self.model.solver._add_variable(var)
-        self._aux_variables[var.name] = var
+        switch_variable = self.model.solver.interface.Variable("y_"+reaction_id, type="binary")
+        self.model.solver._add_variable(switch_variable)
+        self._aux_variables[switch_variable.name] = switch_variable
 
-        constraint_a_id = "c_%s_lb" % reaction_id
         w_u = flux_value + delta * abs(flux_value) + epsilon
-        # vi - yi(vmaxi + w_ui) >= w_ui
-        if reaction.reverse_variable is None:
-            net_variable = reaction.variable
-        else:
-            net_variable = reaction.variable - reaction.reverse_variable
-        expression = add([
-            net_variable,
-            mul([RealNumber(-reaction.upper_bound + w_u), var])])
-        constraint_a = self.model.solver.interface.Constraint(expression, ub=w_u, name=constraint_a_id)
-
-        self._switch_constraints[constraint_a.name] = constraint_a
-        w_l = flux_value - delta * abs(flux_value) - epsilon
-        constraint_b_id = "c_%s_ub" % reaction_id
-        # vi - yi(vmini - w_li) <= w_li
-        expression = add([
-            net_variable,
-            mul([RealNumber(-reaction.lower_bound + w_l), var])])
-        constraint_b = self.model.solver.interface.Constraint(expression, lb=w_l, name=constraint_b_id)
-
-        self._switch_constraints[constraint_b.name] = constraint_b
+        expression = reaction.flux_expression - switch_variable * (reaction.upper_bound - w_u)
+        constraint_a = self.model.solver.interface.Constraint(expression, ub=w_u, name="switch_constraint_%s_lb" % reaction_id)
         self.model.solver._add_constraint(constraint_a)
-        self.model.solver._add_constraint(constraint_b)
-
-    def _add_switch_constraint2(self, reaction_id, flux_value, delta=0.03, epsilon=0.001):
-        reaction = self.model.reactions.get_by_id(reaction_id)
-        var_id = "y_%s" % reaction_id
-        var = self.model.solver.interface.Variable(var_id, type="binary")
-        self.model.solver._add_variable(var)
-        self._aux_variables[var.name] = var
-
-        constraint_a_id = "c_%s_lb" % reaction_id
-        w_u = flux_value + delta * abs(flux_value) + epsilon
-        # vi - yi(vmaxi + w_ui) >= w_ui
-        if reaction.reverse_variable is None:
-            net_variable = reaction.variable
-        else:
-            net_variable = reaction.variable - reaction.reverse_variable
-        expression = add([
-            net_variable,
-            mul([RealNumber(-reaction.upper_bound + w_u), var])])
-        constraint_a = self.model.solver.interface.Constraint(expression, ub=w_u, name=constraint_a_id)
-
         self._switch_constraints[constraint_a.name] = constraint_a
-        w_l = flux_value - delta * abs(flux_value) - epsilon
-        constraint_b_id = "c_%s_ub" % reaction_id
-        # vi - yi(vmini - w_li) <= w_li
-        expression = add([
-            net_variable,
-            mul([RealNumber(-reaction.lower_bound + w_l), var])])
-        constraint_b = self.model.solver.interface.Constraint(expression, lb=w_l, name=constraint_b_id)
 
+        w_l = flux_value - delta * abs(flux_value) - epsilon
+        expression = reaction.flux_expression - switch_variable * (reaction.lower_bound - w_l)
+        constraint_b = self.model.solver.interface.Constraint(expression, lb=w_l, name="switch_constraint_%s_ub" % reaction_id)
         self._switch_constraints[constraint_b.name] = constraint_b
-        self.model.solver._add_constraint(constraint_a)
         self.model.solver._add_constraint(constraint_b)
 
     def minimize(self, *args, **kwargs):

--- a/cameo/flux_analysis/simulation.py
+++ b/cameo/flux_analysis/simulation.py
@@ -78,8 +78,6 @@ def pfba(model, objective=None, *args, **kwargs):
     """
     with TimeMachine() as tm:
         original_objective = model.objective.expression
-        tm(do=partial(setattr, model, 'reversible_encoding', 'split'),
-           undo=partial(setattr, model, 'reversible_encoding', model.reversible_encoding))
         try:
             if objective is not None:
                 tm(do=partial(setattr, model, 'objective', objective),
@@ -320,8 +318,6 @@ def _cycle_free_flux(model, fluxes, fix=[]):
     # import time
     tm = TimeMachine()
     try:
-        tm(do=partial(setattr, model, 'reversible_encoding', 'unsplit'),
-           undo=partial(setattr, model, 'reversible_encoding', model.reversible_encoding))
         exchange_reactions = model.exchanges
         exchange_ids = [exchange.id for exchange in exchange_reactions]
         internal_reactions = [reaction for reaction in model.reactions if reaction.id not in exchange_ids]

--- a/tests/test_cobrapy_compatibility.py
+++ b/tests/test_cobrapy_compatibility.py
@@ -12,18 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import types
-
 import os
-from cobra.test import create_test_model
-from cobra.test.unit_tests import CobraTestCase, TestReactions
-from cobra.test.flux_analysis import TestCobraFluxAnalysis
-
-from cameo.core.solver_based_model import to_solver_based_model, SolverBasedModel
-
 TRAVIS = os.getenv('TRAVIS', False)
 
 if not TRAVIS:
+
+    import types
+    from cobra.test import create_test_model
+    from cobra.test.unit_tests import CobraTestCase, TestReactions
+    from cobra.test.flux_analysis import TestCobraFluxAnalysis
+
+    from cameo.core.solver_based_model import to_solver_based_model, SolverBasedModel
+
+
 
     def setUp(self):
         # Make Model pickable and then load a solver based version of test_pickle


### PR DESCRIPTION
...everse_variable.

Also the following major changes have been introduced:

- reversible_encoding has been eliminated. Everything needs to use v_fwd - v_rev now to model the flux of a reaction.
- reaction.variable is deprecated. Start using reactions.forward_variable

All test miraculously pass ... which is weird. I anticipated flux_variability_analysis would fail because it is not using v_fwd - v_rev explicitily. It doesn't fail though because the objective is set with reactions and SolverBasedModel.objective = reaction will use  v_fwd - v_rev