### PR TITLE
Fixed bugs where changing bounds could give a value error

### DIFF
--- a/cameo/core/reaction.py
+++ b/cameo/core/reaction.py
@@ -191,7 +191,12 @@ class Reaction(_cobrapy.core.Reaction):
                     self._upper_bound = value
                     forward_variable.lb = value
                 else:
-                    reverse_variable.ub = -1*value
+                    try:
+                        reverse_variable.ub = -1*value
+                    except ValueError:
+                        reverse_variable.lb = -1*value
+                        self._upper_bound = value
+                        reverse_variable.ub = -1*value
             else:
                 print({'value': value, 'self._lower_bound': self._lower_bound, 'self._upper_bound': self._upper_bound})
                 raise ValueError('lower_bound issue')
@@ -226,7 +231,12 @@ class Reaction(_cobrapy.core.Reaction):
                     reverse_variable.ub = -1*value
             elif self._lower_bound >= 0: # forward irreversible
                 if value > 0:
-                    forward_variable.ub = value
+                    try:
+                        forward_variable.ub = value
+                    except ValueError:
+                        forward_variable.lb = value
+                        self._lower_bound = value
+                        forward_variable.ub = value
                 else:
                     forward_variable.lb = 0
                     forward_variable.ub = 0


### PR DESCRIPTION
The following raised errors instead of silently changing other bound:

model.reactions.PGI.lower_bound = 1
model.reactions.PGI.upper_bound = 2
model.reactions.PGI.upper_bound = 0.5
=> ValueError

model.reactions.PGI.upper_bound = -1
model.reactions.PGI.lower_bound = -2
model.reactions.PGI.upper_bound = -0.5
=> ValueError