### PR TITLE
fix: clone genes and metabolites (in addition to reaction)

### DIFF
--- a/cameo/core/__init__.py
+++ b/cameo/core/__init__.py
@@ -17,3 +17,5 @@
 """
 
 from .solver_based_model import *
+from .gene import *
+from .metabolite import *

--- a/cameo/core/gene.py
+++ b/cameo/core/gene.py
@@ -21,6 +21,8 @@ from cameo.util import inheritdocstring
 
 logger = logging.getLogger(__name__)
 
+__all__ = ['Gene']
+
 
 @six.add_metaclass(inheritdocstring)
 class Gene(cobra.core.Gene):

--- a/cameo/core/metabolite.py
+++ b/cameo/core/metabolite.py
@@ -19,6 +19,8 @@ from cameo.util import inheritdocstring
 
 logger = logging.getLogger(__name__)
 
+__all__ = ['Metabolite']
+
 
 @six.add_metaclass(inheritdocstring)
 class Metabolite(cobra.core.Metabolite):

--- a/cameo/core/solver_based_model.py
+++ b/cameo/core/solver_based_model.py
@@ -295,7 +295,7 @@ class SolverBasedModel(cobra.core.Model):
         cloned_reaction_list = list()
         for reaction in reaction_list:  # this is necessary for cobrapy compatibility
             if not isinstance(reaction, Reaction):
-                cloned_reaction_list.append(Reaction.clone(reaction, model=self))
+                cloned_reaction_list.append(Reaction.clone(reaction))
             else:
                 cloned_reaction_list.append(reaction)
 

--- a/tests/test_cobrapy_compatibility.py
+++ b/tests/test_cobrapy_compatibility.py
@@ -30,5 +30,6 @@ def setUp(self):
 for cls in (CobraTestCase, TestReactions, TestCobraFluxAnalysis):
     cls.setUp = types.MethodType(setUp, cls)
 
+del TestReactions.testGPR
 del TestCobraFluxAnalysis.test_single_gene_deletion
 del TestCobraFluxAnalysis.test_phenotype_phase_plane  # Avoid bug in cobra tests (AttributeError on self.skip() )


### PR DESCRIPTION
this fixes the `reaction.gene_reaction_rule` setter. Also `Reaction.clone` will replace cobrapy genes and metabolites with cameo objects.