### PR TITLE
New version of metabolite knock_out keeping the steady-state constraints.

### DIFF
--- a/cameo/core/solver_based_model.py
+++ b/cameo/core/solver_based_model.py
@@ -30,7 +30,6 @@ import cobra
 import optlang
 import six
 import sympy
-from cobra.manipulation import find_gene_knockout_reactions
 from pandas import DataFrame, pandas
 from sympy import Add
 from sympy import Mul
@@ -480,7 +479,7 @@ class SolverBasedModel(cobra.core.Model):
         fields.remove('optimize')
         return fields
 
-    def essential_metabolites(self, threshold=1e-6, absolute_bound=100000, force_steady_state=False):
+    def essential_metabolites(self, threshold=1e-6, force_steady_state=False):
         """Return a list of essential metabolites.
 
         This can be done in 2 ways:
@@ -503,9 +502,8 @@ class SolverBasedModel(cobra.core.Model):
         ----------
         threshold : float (default 1e-6)
             Minimal objective flux to be considered viable.
-        absolute_bound: number
-            The metabolites is 'knocked-out' by setting the associated constraints in the S-matrix to -absolute_bound
-            <= Si <= absolute_bound so should be a large number to make it effectively unconstrained.
+        force_steady_state: bool
+            If True, uses approach 2.
 
         References
         ----------
@@ -526,9 +524,7 @@ class SolverBasedModel(cobra.core.Model):
 
         for metabolite in metabolites:
             with TimeMachine() as tm:
-                metabolite.knock_out(time_machine=tm,
-                                     absolute_bound=absolute_bound,
-                                     force_steady_state=force_steady_state)
+                metabolite.knock_out(time_machine=tm, force_steady_state=force_steady_state)
                 try:
                     solution = self.solve()
                     if solution.f < threshold:

--- a/cameo/core/solver_based_model.py
+++ b/cameo/core/solver_based_model.py
@@ -514,7 +514,17 @@ class SolverBasedModel(cobra.core.Model):
         """
 
         essential_metabolites = []
-        for metabolite in self.metabolites:
+
+        # Essential metabolites are only in reactions that carry flux.
+        metabolites = set()
+        solution = self.solve()
+
+        for reaction_id, flux in six.iteritems(solution.fluxes):
+            if abs(flux) > 0:
+                reaction = self.reactions.get_by_id(reaction_id)
+                metabolites.update(reaction.metabolites.keys())
+
+        for metabolite in metabolites:
             with TimeMachine() as tm:
                 metabolite.knock_out(time_machine=tm,
                                      absolute_bound=absolute_bound,

--- a/tests/test_solver_based_model.py
+++ b/tests/test_solver_based_model.py
@@ -21,20 +21,20 @@ import os
 import pickle
 import unittest
 
+import cobra
 import numpy
 import optlang
 import pandas
 import six
-import cobra
 from cobra.io import read_sbml_model
 
 import cameo
 from cameo import load_model, Model
 from cameo.config import solvers
+from cameo.core.gene import Gene
+from cameo.core.metabolite import Metabolite
 from cameo.core.solver_based_model import Reaction
 from cameo.exceptions import UndefinedSolution
-from cameo.core.metabolite import Metabolite
-from cameo.core.gene import Gene
 from cameo.util import TimeMachine
 
 TRAVIS = os.getenv('TRAVIS', False)
@@ -1075,12 +1075,12 @@ class WrappedAbstractTestMetabolite:
             rxn.add_metabolites({metabolite_a: -1, metabolite_b: 1})
             model.add_reaction(rxn)
             with TimeMachine() as tm:
-                metabolite_a.knock_out(time_machine=tm, absolute_bound=10000)
+                metabolite_a.knock_out(time_machine=tm)
                 self.assertEquals(rxn.upper_bound, 0)
-                metabolite_b.knock_out(time_machine=tm, absolute_bound=10000)
+                metabolite_b.knock_out(time_machine=tm)
                 self.assertEquals(rxn.lower_bound, 0)
-                self.assertEquals(metabolite_a.constraint.lb, -10000)
-                self.assertEquals(metabolite_a.constraint.ub, 10000)
+                self.assertEquals(metabolite_a.constraint.lb, -1000 * len(metabolite_a.reactions))
+                self.assertEquals(metabolite_a.constraint.ub, 1000 * len(metabolite_a.reactions))
             self.assertEquals(metabolite_a.constraint.lb, 0)
             self.assertEquals(metabolite_a.constraint.ub, 0)
             self.assertEquals(rxn.upper_bound, 10)

--- a/tests/test_solver_based_model.py
+++ b/tests/test_solver_based_model.py
@@ -958,6 +958,21 @@ class WrappedAbstractTestSolverBasedModel:
                 self.model.reactions.Biomass_Ecoli_core_N_LPAREN_w_FSLASH_GAM_RPAREN__Nmet2.lower_bound = 999999.
                 self.model.essential_reactions()
 
+        def test_essential_metabolites(self):
+            model = self.model.copy()
+            essential_metabolites_unbalanced = [m.id for m in model.essential_metabolites(force_steady_state=False)]
+            essential_metabolites_balanced = [m.id for m in model.essential_metabolites(force_steady_state=True)]
+            self.assertTrue(sorted(essential_metabolites_unbalanced) == sorted(ESSENTIAL_METABOLITES))
+            self.assertTrue(sorted(essential_metabolites_balanced) == sorted(ESSENTIAL_METABOLITES))
+
+            with self.assertRaises(cameo.exceptions.SolveError):
+                self.model.reactions.Biomass_Ecoli_core_N_LPAREN_w_FSLASH_GAM_RPAREN__Nmet2.lower_bound = 999999.
+                self.model.essential_metabolites(force_steady_state=False)
+
+            with self.assertRaises(cameo.exceptions.SolveError):
+                self.model.reactions.Biomass_Ecoli_core_N_LPAREN_w_FSLASH_GAM_RPAREN__Nmet2.lower_bound = 999999.
+                self.model.essential_metabolites(force_steady_state=True)
+
         def test_effective_bounds(self):
             self.model.reactions.Biomass_Ecoli_core_N_LPAREN_w_FSLASH_GAM_RPAREN__Nmet2.lower_bound = 0.873921
             for reaction in self.model.reactions:
@@ -1070,14 +1085,6 @@ class WrappedAbstractTestMetabolite:
             self.assertEquals(metabolite_a.constraint.ub, 0)
             self.assertEquals(rxn.upper_bound, 10)
             self.assertEquals(rxn.lower_bound, -10)
-
-        def test_essential_metabolites(self):
-            model = self.model.copy()
-            essential_metabolites = [m.id for m in model.essential_metabolites()]
-            self.assertTrue(sorted(essential_metabolites) == sorted(ESSENTIAL_METABOLITES))
-            with self.assertRaises(cameo.exceptions.SolveError):
-                self.model.reactions.Biomass_Ecoli_core_N_LPAREN_w_FSLASH_GAM_RPAREN__Nmet2.lower_bound = 999999.
-                self.model.essential_genes()
 
         def test_remove_from_model(self):
             met = self.model.metabolites.get_by_id("g6p_c")


### PR DESCRIPTION
Same assumptions as before but now I am adding a sink to the metabolite being knocked out instead of removing relaxing the mass balance constraint.

@KristianJensen, @phantomas1234 I need you to take a fresh look at this please. Two weird things going on:
1. cplex does not raise SolverError any time when I set the lower bound of the objective to 99999.
2. GLPK is returning UndefinedSolution error.

Any thoughts?
