### PR TITLE
Minor fix: give a list of reactions to remove

### DIFF
--- a/cameo/core/target.py
+++ b/cameo/core/target.py
@@ -230,7 +230,7 @@ class ReactionKnockinTarget(KnockinTarget):
             model.add_reaction(self._value)
         else:
             time_machine(do=partial(model.add_reaction, self._value),
-                         undo=partial(model.remove_reactions, self._value, delete=False, remove_orphans=True))
+                         undo=partial(model.remove_reactions, [self._value], delete=False, remove_orphans=True))
 
     def to_gnomic(self):
         accession = Target.to_gnomic(self)


### PR DESCRIPTION
Use [self._value] when providing the argument for model.remove_reactions so it doesn't display unnecessary warnings.