### PR TITLE
Fix: Nicer CLI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,6 +69,17 @@ of host organisms using the high-level interface.
 
 `Output <http://nbviewer.ipython.org/github/biosustain/cameo-notebooks/blob/master/8-high-level-API.ipynb>`__
 
+
+Command Line Interface (for users)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The API can be called directly from the command line.
+For more information about how to run it, open your terminal and run:
+
+::
+
+   cameo --helo
+
 Low-level API (for developers)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/cameo/cli/controllers.py
+++ b/cameo/cli/controllers.py
@@ -52,7 +52,7 @@ class BaseController(CementBaseController):
     def default(self):
         print("Welcome to cameo. For more information run cameo --help.")
 
-    @expose(help="Find design for a product of interest\n"
+    @expose(help="Find strain designs for a product of interest\n"
                  "    Usage: cameo design --product=acetate\n"
                  "    For more information see the arguments bellow.\n")
     def design(self):

--- a/cameo/cli/controllers.py
+++ b/cameo/cli/controllers.py
@@ -50,6 +50,12 @@ class BaseController(CementBaseController):
 
     @expose(hide=True)
     def default(self):
+        print("Welcome to cameo. For more information run cameo --help.")
+
+    @expose(help="Find design for a product of interest\n"
+                 "    Usage: cameo design --product=acetate\n"
+                 "    For more information see the arguments bellow.\n")
+    def design(self):
         product = None
         output_format = None
         auto_select = self.app.pargs.yes_all

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,9 @@ requirements = ['numpy>=1.9.1',
                 'inspyred>=1.0',
                 'lazy-object-proxy>=1.2.0',
                 'palettable>=2.1.1',
-                'gnomic>=0.2.0']
+                'gnomic>=0.2.0',
+                'openpyxl>=2.4.5',
+                'cement>=2.10.2']
 
 extra_requirements = {
     'docs': ['Sphinx>=1.3.5', 'numpydoc>=0.5'],
@@ -50,7 +52,6 @@ extra_requirements = {
     'test': ['pytest', 'pytest-cov'],
     'parallel': ['redis>=2.10.5', 'ipyparallel>=5.0.1'],
     'sbml': ['python-libsbml>=5.13.0', 'lxml>=3.6.0'],
-    'cli': ['cement>=2.10.2', 'xlwt>=1.2.0']
 }
 extra_requirements['all'] = list(set(chain(*extra_requirements.values())))
 


### PR DESCRIPTION
Make CLI nicer for the user:

Features: 
* Running `cameo` will display and welcome message and point to `--help`
* Two methods `cameo design` and `cameo search`. The first runs the API the second just searches for metabolites
* Updated documentation.
* Use pyopenxl to generate xlsx files

```
$ cameo
Welcome to cameo. For more information run cameo --help.
```
```
$cameo --help
usage: cameo (sub-commands ...) [options ...] {arguments ...}

cameo high-level API

commands:

  design
    Find design for a product of interest
    Usage: cameo design --product=acetate
    For more information see the arguments bellow.

  search
    Search for products in our internal database

optional arguments:
  -h, --help            show this help message and exit
  --debug               toggle debug output
  --quiet               suppress all output
  --host HOST           Host to test
  -p PRODUCT, --product PRODUCT
                        The product to optimize
  -a, --anaerobic       Run anaerobic
  -m, --multiprocess    Run multiprocess mode
  -c CORES, --cores CORES
                        Number of cores (if multiprocess)
  -o OUTPUT, --output OUTPUT
                        Output file
  -of OUTPUT_FORMAT, --output-format OUTPUT_FORMAT
                        Output file format (default xlsx) Options:['xlsx',
                        'csv', 'tsv']
  -y, --yes-all         Auto select suggested options
  -t, --test            Test mode
``` 