### PR TITLE
fix: make add_pfba roll back all changes

### DIFF
--- a/cameo/flux_analysis/simulation.py
+++ b/cameo/flux_analysis/simulation.py
@@ -106,7 +106,7 @@ def add_pfba(model, objective=None, fraction_of_optimum=1.0, time_machine=None):
         A time machine to undo the added pFBA objective
     """
     if objective is not None:
-        model.objective = objective
+        model.change_objective(objective, time_machine=time_machine)
     if model.solver.objective.name == '_pfba_objective':
         raise ValueError('model already has pfba objective')
     if fraction_of_optimum > 0:


### PR DESCRIPTION
So this fixes (for whatever reason) optgene crashing with an infeasible model in https://github.com/biosustain/cameo-notebooks/blob/master/09-vanillin-production.ipynb. In any case, I'd say all changes need to roll back in a method that provides a time_machine kwarg.