### PR TITLE
feat: quick fix for reading gzipped files under Python 2 on Windows

### DIFF
--- a/cameo/data/metanetx.py
+++ b/cameo/data/metanetx.py
@@ -26,7 +26,13 @@ import pandas
 import cameo
 
 
-with gzip.open(os.path.join(cameo._cameo_data_path, 'metanetx.json.gz'), 'rt') as f:
+if six.PY2:
+    flag = 'r'
+else:
+    flag = 'rt'
+
+with gzip.open(os.path.join(cameo._cameo_data_path, 'metanetx.json.gz'),
+               flag) as f:
     _METANETX = json.load(f)
 
 bigg2mnx = _METANETX['bigg2mnx']
@@ -34,5 +40,6 @@ mnx2bigg = _METANETX['mnx2bigg']
 all2mnx = _METANETX['all2mnx']
 mnx2all = {v: k for k, v in six.iteritems(all2mnx)}
 
-with gzip.open(os.path.join(cameo._cameo_data_path, 'metanetx_chem_prop.json.gz'), 'rt') as f:
+with gzip.open(os.path.join(cameo._cameo_data_path,
+                            'metanetx_chem_prop.json.gz'), flag) as f:
     chem_prop = pandas.read_json(f)


### PR DESCRIPTION
The stdlib gzip module always adds binary mode 'b' to the read flag. This was
causing a `ValueError` on Python 2 under Windows.

Unfortunately, we can't test this properly until AppVeyor is enabled.