### PR TITLE
Fix: essential metabolites method breaks with some solvers

### DIFF
--- a/cameo/flux_analysis/analysis.py
+++ b/cameo/flux_analysis/analysis.py
@@ -94,7 +94,7 @@ def knock_out_metabolite(metabolite, force_steady_state=False):
                                        reaction_id="KO_{}".format(metabolite.id))
     else:
         previous_bounds = metabolite.constraint.lb, metabolite.constraint.ub
-        metabolite.constraint.lb, metabolite.constraint.ub = None, None
+        metabolite.constraint.lb, metabolite.constraint.ub = -1000, 1000
         context = get_context(metabolite)
         if context:
             def reset():


### PR DESCRIPTION
```~/Documents/repos/cameo/cameo/flux_analysis/analysis.py in knock_out_metabolite(metabolite, force_steady_state)
     96         previous_bounds = metabolite.constraint.lb, metabolite.constraint.ub
---> 97         metabolite.constraint.lb, metabolite.constraint.ub = None, None
     98         context = get_context(metabolite)

~/miniconda2/envs/marsi/lib/python3.5/site-packages/optlang/cplex_interface.py in ub(self, value)
    313                 )
--> 314             sense, rhs, range_value = _constraint_lb_and_ub_to_cplex_sense_rhs_and_range_value(self.lb, value)
    315             if self.is_Linear:

~/miniconda2/envs/marsi/lib/python3.5/site-packages/optlang/cplex_interface.py in _constraint_lb_and_ub_to_cplex_sense_rhs_and_range_value(lb, ub)
    143     if lb is None and ub is None:
--> 144         raise Exception("Free constraint ...")
    145     elif lb is None:

Exception: Free constraint ...```