### PR TITLE
Fix: run essential genes and essential reactions as a single process

### DIFF
--- a/cameo/strain_design/deterministic/linear_programming.py
+++ b/cameo/strain_design/deterministic/linear_programming.py
@@ -131,7 +131,7 @@ class OptKnock(StrainDesignMethod):
     def _build_problem(self, essential_reactions, use_nullspace_simplification):
         logger.debug("Starting to formulate OptKnock problem")
 
-        self.essential_reactions = find_essential_reactions(self._model).union(self._model.exchanges)
+        self.essential_reactions = find_essential_reactions(self._model, processes=1).union(self._model.exchanges)
         if essential_reactions:
             self.essential_reactions.update(set(get_reaction_for(self._model, r) for r in essential_reactions))
 

--- a/cameo/strain_design/heuristic/evolutionary/multiprocess/optimization.py
+++ b/cameo/strain_design/heuristic/evolutionary/multiprocess/optimization.py
@@ -214,7 +214,7 @@ class MultiprocessReactionKnockoutOptimization(MultiprocessKnockoutOptimization)
             self.reactions = reactions
 
         if essential_reactions is None:
-            self.essential_reactions = set([r.id for r in find_essential_reactions(self.model)])
+            self.essential_reactions = set([r.id for r in find_essential_reactions(self.model, processes=1)])
         else:
             self.essential_reactions = essential_reactions
 
@@ -257,7 +257,7 @@ class MultiprocessGeneKnockoutOptimization(MultiprocessKnockoutOptimization):
             self.genes = genes
 
         if essential_genes is None:
-            self.essential_genes = set([g.id for g in find_essential_genes(self.model)])
+            self.essential_genes = set([g.id for g in find_essential_genes(self.model, processes=1)])
         else:
             self.essential_genes = essential_genes
 

--- a/cameo/strain_design/heuristic/evolutionary/optimization.py
+++ b/cameo/strain_design/heuristic/evolutionary/optimization.py
@@ -670,9 +670,10 @@ class ReactionKnockoutOptimization(KnockoutOptimization):
             self.reactions = reactions
         logger.debug("Computing essential reactions...")
         if essential_reactions is None:
-            self.essential_reactions = set(r.id for r in find_essential_reactions(self.model))
+            self.essential_reactions = set(r.id for r in find_essential_reactions(self.model, processes=1))
         else:
-            self.essential_reactions = set([r.id for r in find_essential_reactions(self.model)] + essential_reactions)
+            self.essential_reactions = set([r.id for r in find_essential_reactions(self.model, processes=1)]
+                                           + essential_reactions)
 
         if use_nullspace_simplification:
             ns = nullspace(create_stoichiometric_array(self.model))
@@ -763,9 +764,9 @@ class GeneKnockoutOptimization(KnockoutOptimization):
         else:
             self.genes = genes
         if essential_genes is None:
-            self.essential_genes = {g.id for g in find_essential_genes(self.model)}
+            self.essential_genes = {g.id for g in find_essential_genes(self.model, processes=1)}
         else:
-            self.essential_genes = set([g.id for g in find_essential_genes(self.model)] + essential_genes)
+            self.essential_genes = set([g.id for g in find_essential_genes(self.model, processes=1)] + essential_genes)
 
         # TODO: use genes from groups
         if use_nullspace_simplification:

--- a/cameo/strain_design/heuristic/evolutionary/optimization.py
+++ b/cameo/strain_design/heuristic/evolutionary/optimization.py
@@ -672,8 +672,8 @@ class ReactionKnockoutOptimization(KnockoutOptimization):
         if essential_reactions is None:
             self.essential_reactions = set(r.id for r in find_essential_reactions(self.model, processes=1))
         else:
-            self.essential_reactions = set([r.id for r in find_essential_reactions(self.model, processes=1)]
-                                           + essential_reactions)
+            self.essential_reactions = set([r.id for r in find_essential_reactions(self.model, processes=1)])
+            self.essential_reactions.update(essential_reactions)
 
         if use_nullspace_simplification:
             ns = nullspace(create_stoichiometric_array(self.model))


### PR DESCRIPTION
Running cameo in with multiprocessing view breaks when calling `find_essential_genes` or `find_essential_reactions` because they spawn new processes, unless when run as a single process.

Because find these essential elements is not the limiting step of the algorithms implemented here, we can run them in single process mode, without compromising much cameo runtime.

Fixes #195 