### PR TITLE
fix: use `mode=lines` instead of `model=line` in new plotly API

### DIFF
--- a/cameo/visualization/plotting/with_plotly.py
+++ b/cameo/visualization/plotting/with_plotly.py
@@ -120,7 +120,7 @@ class PlotlyPlotter(AbstractPlotter):
             y.extend([lb[0], ub[0]])
 
         scatter = go.Scatter(x=x, y=y,
-                             mode="line",
+                             mode="lines",
                              name=variable,
                              hoverinfo='none',
                              fillcolor=color,

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ requirements = ['numpy>=1.9.1',
 
 extra_requirements = {
     'docs': ['Sphinx>=1.3.5', 'numpydoc>=0.5'],
-    'plotly': ['plotly>=1.9.6'],
+    'plotly': ['plotly>=3.0.0'],
     'bokeh': ['bokeh<=0.12.1'],
     'jupyter': ['jupyter>=1.0.0', 'ipywidgets>=4.1.1'],
     'test': ['pytest', 'pytest-cov', 'pytest-benchmark'],


### PR DESCRIPTION
fixes #217