### PR TITLE
Update path to pandas ipynb test

### DIFF
--- a/cameo/util.py
+++ b/cameo/util.py
@@ -537,7 +537,7 @@ def in_ipnb():
     """
     Check if it is running inside an IPython Notebook (updated for new notebooks)
     """
-    return pandas.core.common.in_ipython_frontend()
+    return pandas.io.formats.console.in_ipython_frontend()
 
 
 def str_to_valid_variable_name(s):

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ import versioneer
 requirements = ['numpy>=1.9.1',
                 'scipy>=0.14.0',
                 'blessings>=1.5.1',
-                'pandas>=0.20.2',
+                'pandas>=0.24.0',
                 'ordered-set>=1.2',
                 'cobra>=0.11.1',
                 'future>=0.15.2',


### PR DESCRIPTION
In pandas 0.24.0 and above, the internal `in_ipython_frontend` function
has been moved. This updates the reference, but it is still an internal
module and may break at any time so consider replacing it with something
more permanent.