### PR TITLE
Deprecation sympy ups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,6 @@ matrix:
       env: TOXENV=py36
     - python: '3.7'
       env: TOXENV=py37
-    - python: '3.8'
-      env: TOXENV=py38
 
 branches:
  only:

--- a/cameo/flux_analysis/simulation.py
+++ b/cameo/flux_analysis/simulation.py
@@ -48,8 +48,8 @@ logger = logging.getLogger(__name__)
 
 add = Add._from_args
 mul = Mul._from_args
-NegativeOne = sympy.singleton.S.NegativeOne
-One = sympy.singleton.S.One
+NegativeOne = sympy.S.NegativeOne
+One = sympy.S.One
 FloatOne = sympy.Float(1)
 RealNumber = sympy.RealNumber
 


### PR DESCRIPTION
Use sympy newer sympy API to avoid deprecation warnings:

![sympy DeprecationWarning](https://user-images.githubusercontent.com/46683255/98352787-c91a8c00-201e-11eb-92a8-ccbf38357fbd.png)
