### PR TITLE
Refactor bounds behaviour

### DIFF
--- a/cameo/flux_analysis/simulation.py
+++ b/cameo/flux_analysis/simulation.py
@@ -518,9 +518,10 @@ class FluxDistributionResult(Result):
 
             if in_ipnb():
                 from IPython.display import display
-                display(builder.display_in_notebook())
+                display(builder)
             else:
-                builder.display_in_browser()
+                logger.info(f"Escher Map generated at {map_name}.html")
+                builder.save_html(f"{map_name}.html")
 
         except ImportError:
             print("Escher must be installed in order to visualize maps")

--- a/cameo/strain_design/deterministic/flux_variability_based.py
+++ b/cameo/strain_design/deterministic/flux_variability_based.py
@@ -77,7 +77,7 @@ class DifferentialFVA(StrainDesignMethod):
 
     Compares flux ranges of a reference model to a set of models that
     have been parameterized to lie on a grid of evenly spaced points in the
-    n-dimensional production envelope (n being the number of reaction bounds
+    # n-dimensional production envelope (n being the number of reaction bounds
     to be varied).
     ::
         production
@@ -626,9 +626,11 @@ class DifferentialFVAResult(StrainDesignMethodResult):
         """
         return self.groups.get_group(sorted(self.groups.groups.keys())[index]).copy()
 
-    def plot(self, index=None, variables=None, grid=None, width=None, height=None, title=None, palette=None, **kwargs):
+    def plot(self, plotter, index=None, variables=None, grid=None, width=None, height=None, title=None, palette=None, **kwargs):
         if index is not None:
-            self._plot_flux_variability_analysis(index, variables=variables, width=width, grid=grid, palette=palette)
+            self._plot_flux_variability_analysis(
+                plotter, index, variables=variables, width=width, grid=grid, palette=palette
+            )
         else:
             self._plot_production_envelope(title=title, grid=grid, width=width, height=height)
 
@@ -768,9 +770,10 @@ class DifferentialFVAResult(StrainDesignMethodResult):
 
             if in_ipnb():
                 from IPython.display import display
-                display(builder.display_in_notebook())
+                display(builder)
             else:
-                builder.display_in_browser()
+                logger.info(f"Escher Map generated at {map_name}.html")
+                builder.save_html(f"{map_name}.html")
 
         except ImportError:
             print("Escher must be installed in order to visualize maps")
@@ -821,7 +824,7 @@ class _MapView(object):
                                            dict(type='min', color="red", size=20),
                                            dict(type='median', color="grey", size=7),
                                            dict(type='max', color='green', size=20)], **self.kwargs_for_escher)
-        display(self.builder.display_in_notebook())
+        display(self.builder)
 
 
 class _DifferentialFvaEvaluator(object):

--- a/cameo/strain_design/deterministic/flux_variability_based.py
+++ b/cameo/strain_design/deterministic/flux_variability_based.py
@@ -626,7 +626,18 @@ class DifferentialFVAResult(StrainDesignMethodResult):
         """
         return self.groups.get_group(sorted(self.groups.groups.keys())[index]).copy()
 
-    def plot(self, plotter, index=None, variables=None, grid=None, width=None, height=None, title=None, palette=None, **kwargs):
+    def plot(
+        self,
+        plotter,
+        index=None,
+        variables=None,
+        grid=None,
+        width=None,
+        height=None,
+        title=None,
+        palette=None,
+        **kwargs
+    ):
         if index is not None:
             self._plot_flux_variability_analysis(
                 plotter, index, variables=variables, width=width, grid=grid, palette=palette

--- a/cameo/strain_design/deterministic/flux_variability_based.py
+++ b/cameo/strain_design/deterministic/flux_variability_based.py
@@ -862,7 +862,7 @@ class _DifferentialFvaEvaluator(object):
             reaction.upper_bound = reaction.lower_bound = bound
         target_reaction = self.model.reactions.get_by_id(self.objective)
         target_bound = point[self.objective]
-        target_reaction.upper_bound = target_reaction.lower_bound = target_bound
+        target_reaction.bounds = (target_bound, target_bound)
 
 
 class FSEOF(StrainDesignMethod):
@@ -978,10 +978,9 @@ class FSEOF(StrainDesignMethod):
             results = {reaction.id: [] for reaction in model.reactions}
 
             for level in levels:
-                target.lower_bound = level
-                target.upper_bound = level
+                target.bounds = (level, level)
                 solution = simulation_method(model, **simulation_kwargs)
-                for reaction_id, flux in solution.fluxes.iteritems():
+                for reaction_id, flux in solution.fluxes.items():
                     results[reaction_id].append(round(flux, ndecimals))
 
         # Test each reaction

--- a/cameo/visualization/escher_ext.py
+++ b/cameo/visualization/escher_ext.py
@@ -99,4 +99,4 @@ class NotebookBuilder(escher.Builder):
         return draw
 
     def _repr_html_(self):
-        return self.display_in_notebook()
+        return display(self)

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -69,6 +69,7 @@ Both plotly and escher require additional steps to work with jupyter lab. For es
 For plotly (based on plotly-docs_), identify your version of plotly:
 
 .. code-block:: guess
+
     $ pip freeze | grep plotly  # e.g. 4.14.3 
     $ python -m jupyter labextension install jupyterlab-plotly@4.14.3
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -21,7 +21,7 @@ be installed using virtualenv-burrito_. Once you installed virtualenv_ and virtu
     $ mkvirtualenv cameo  # or whatever you'd like to call your virtual environment
     $ workon cameo
 
-and then continue with the installation instructions described above.
+and then continue with the installation instructions described below.
 
 Alternatively you can use `conda` if you are an `Anaconda <https://anaconda.org/>`__ user (there is no conda recipe for cameo though so you'll
 still need to install it using `pip`). Do the following to create a virtual environment and get some of the heavier dependencies out of the way.
@@ -30,7 +30,7 @@ still need to install it using `pip`). Do the following to create a virtual envi
 
     $ conda create -y -n cameo3.4 python=3.4 lxml scipy pandas numexpr matplotlib
 
-Then follow the basic installation instructions described above.
+Then follow the basic installation instructions described below.
 
 Soft dependencies
 =================
@@ -50,14 +50,31 @@ or individually by specifying individual categories of dependencies. For example
 The following categories are available::
 
     'docs': ['Sphinx>=1.3.5', 'numpydoc>=0.5'],
-    'plotly': ['plotly>=1.9.6'],
+    'plotly': ['plotly>=4.12.0'],
     'bokeh': ['bokeh<=0.12.1'],
     'jupyter': ['jupyter>=1.0.0', 'ipywidgets>=4.1.1'],
-    'test': ['pytest', 'pytest-cov'],
+    'test': ['pytest', 'pytest-cov', 'pytest-benchmark'],
     'parallel': ['redis>=2.10.5', 'ipyparallel>=5.0.1'],
     'sbml': ['python-libsbml>=5.13.0', 'lxml>=3.6.0']
 
+Working with jupyter lab
+========================
+Both plotly and escher require additional steps to work with jupyter lab. For escher (based on escher-readme_):
+
+.. code-block:: guess
+
+    $ jupyter labextension install @jupyter-widgets/jupyterlab-manager
+    $ python -m jupyter labextension install escher
+
+For plotly (based on plotly-docs_), identify your version of plotly:
+
+.. code-block:: guess
+    $ pip freeze | grep plotly  # e.g. 4.14.3 
+    $ python -m jupyter labextension install jupyterlab-plotly@4.14.3
+
+.. _escher-readme: https://github.com/zakandrewking/escher/#jupyter-extensions
+.. _plotly-docs: https://plotly.com/python/getting-started/#jupyterlab-support
 .. _optlang: https://github.com/biosustain/optlang
 .. _virtualenv-burrito: https://github.com/brainsik/virtualenv-burrito
-.. _virtualenv: https://pypi.python.org/pypi/virtualenv
 .. _virtualenvwrapper: https://pypi.python.org/pypi/virtualenvwrapper
+.. _virtualenv: https://pypi.python.org/pypi/virtualenv

--- a/tests/test_solver_based_model.py
+++ b/tests/test_solver_based_model.py
@@ -187,7 +187,8 @@ class TestReaction:
         assert acald_reaction.forward_variable.ub == 1000.
         assert acald_reaction.reverse_variable.lb == 0
         assert acald_reaction.reverse_variable.ub == 1000.
-        acald_reaction.bounds = (acald_reaction.lower_bound - 100,) * 2
+        fixed_flux = acald_reaction.lower_bound - 100
+        acald_reaction.bounds = (fixed_flux, fixed_flux)
         assert acald_reaction.lower_bound == -1100.0
         assert acald_reaction.upper_bound == -1100.0
         assert acald_reaction.forward_variable.lb == 0
@@ -208,8 +209,8 @@ class TestReaction:
         assert reac.lower_bound == 0
         assert reac.upper_bound == 0
         reac.bounds = (-2, -2)
-        assert reac.lower_bound == -2
-        assert reac.upper_bound == -2
+        assert reac.forward_variable.lb == 0
+        assert reac.forward_variable.ub == 0
         reac.bounds = (2, 2)
         assert reac.reverse_variable.lb == 0
         assert reac.reverse_variable.ub == 0
@@ -232,7 +233,8 @@ class TestReaction:
         assert acald_reaction.forward_variable.ub == 1000.
         assert acald_reaction.reverse_variable.lb == 0
         assert acald_reaction.reverse_variable.ub == 1000.
-        acald_reaction.bounds = (acald_reaction.upper_bound + 100,) * 2
+        fixed_flux = acald_reaction.upper_bound + 100
+        acald_reaction.bounds = (fixed_flux, fixed_flux)
         assert acald_reaction.lower_bound == 1100.0
         assert acald_reaction.upper_bound == 1100.0
         assert acald_reaction.forward_variable.lb == 1100.0

--- a/tests/test_solver_based_model.py
+++ b/tests/test_solver_based_model.py
@@ -187,7 +187,7 @@ class TestReaction:
         assert acald_reaction.forward_variable.ub == 1000.
         assert acald_reaction.reverse_variable.lb == 0
         assert acald_reaction.reverse_variable.ub == 1000.
-        acald_reaction.upper_bound = acald_reaction.lower_bound - 100
+        acald_reaction.bounds = (acald_reaction.lower_bound - 100,) * 2
         assert acald_reaction.lower_bound == -1100.0
         assert acald_reaction.upper_bound == -1100.0
         assert acald_reaction.forward_variable.lb == 0
@@ -204,39 +204,15 @@ class TestReaction:
 
     def test_set_bounds_scenario_3(self, core_model):
         reac = core_model.reactions.ACALD
-        reac.bounds = -10, -10
-        assert reac.lower_bound == -10
-        assert reac.upper_bound == -10
-        reac.lower_bound = -9
-        assert reac.lower_bound == -9
-        assert reac.upper_bound == -9
-        reac.lower_bound = 2
-        assert reac.lower_bound == 2
-        assert reac.upper_bound == 2
-        reac.upper_bound = -10
-        assert reac.lower_bound == -10
-        assert reac.upper_bound == -10
-        reac.upper_bound = -11
-        assert reac.lower_bound == -11
-        assert reac.upper_bound == -11
-        reac.upper_bound = 2
-        assert reac.lower_bound == -11
-        assert reac.upper_bound == 2
-
-    def test_set_bounds_scenario_4(self, core_model):
-        reac = core_model.reactions.ACALD
-        reac.lower_bound = reac.upper_bound = 0
-        reac.lower_bound = 2
-        assert reac.lower_bound == 2
-        assert reac.upper_bound == 2
-        assert reac.forward_variable.lb == 2
-        assert reac.forward_variable.ub == 2
         reac.knock_out()
-        reac.upper_bound = -2
+        assert reac.lower_bound == 0
+        assert reac.upper_bound == 0
+        reac.bounds = (-2, -2)
         assert reac.lower_bound == -2
         assert reac.upper_bound == -2
-        assert reac.reverse_variable.lb == 2
-        assert reac.reverse_variable.ub == 2
+        reac.bounds = (2, 2)
+        assert reac.reverse_variable.lb == 0
+        assert reac.reverse_variable.ub == 0
 
     def test_set_upper_before_lower_bound_to_0(self, core_model):
         core_model.reactions.GAPD.bounds = 0, 0
@@ -256,7 +232,7 @@ class TestReaction:
         assert acald_reaction.forward_variable.ub == 1000.
         assert acald_reaction.reverse_variable.lb == 0
         assert acald_reaction.reverse_variable.ub == 1000.
-        acald_reaction.lower_bound = acald_reaction.upper_bound + 100
+        acald_reaction.bounds = (acald_reaction.upper_bound + 100,) * 2
         assert acald_reaction.lower_bound == 1100.0
         assert acald_reaction.upper_bound == 1100.0
         assert acald_reaction.forward_variable.lb == 1100.0
@@ -277,7 +253,7 @@ class TestReaction:
         assert reac.lower_bound == 2
         assert reac.upper_bound == 2
         with core_model:
-            reac.lower_bound = 5
+            reac.bounds = (5, 5)
             assert reac.lower_bound == 5
             assert reac.upper_bound == 5
         assert reac.lower_bound == 2
@@ -337,7 +313,7 @@ class TestReaction:
         assert pfk_reaction.forward_variable.ub == 1000.
         assert pfk_reaction.reverse_variable.lb == 0
         assert pfk_reaction.reverse_variable.ub == 0
-        pfk_reaction.upper_bound = -100.
+        pfk_reaction.bounds = (-100, -100)
         assert pfk_reaction.forward_variable.lb == 0
         assert pfk_reaction.forward_variable.ub == 0
         assert pfk_reaction.reverse_variable.lb == 100
@@ -392,8 +368,7 @@ class TestReaction:
             assert reaction.lower_bound == 0
             assert reaction.upper_bound == 0
         for k, (lb, ub) in original_bounds.items():
-            core_model.reactions.get_by_id(k).lower_bound = lb
-            core_model.reactions.get_by_id(k).upper_bound = ub
+            core_model.reactions.get_by_id(k).bounds = (lb, ub)
         for reaction in core_model.reactions:
             assert reaction.lower_bound == original_bounds[reaction.id][0]
             assert reaction.upper_bound == original_bounds[reaction.id][1]
@@ -511,18 +486,6 @@ class TestReaction:
         rxn.upper_bound = prev_ub
         assert rxn.lower_bound == prev_lb
         assert rxn.upper_bound == prev_ub
-
-    def test_set_lb_higher_than_ub_sets_ub_to_new_lb(self, core_model):
-        for reaction in core_model.reactions:
-            assert reaction.lower_bound <= reaction.upper_bound
-            reaction.lower_bound = reaction.upper_bound + 100
-            assert reaction.lower_bound == reaction.upper_bound
-
-    def test_set_ub_lower_than_lb_sets_lb_to_new_ub(self, core_model):
-        for reaction in core_model.reactions:
-            assert reaction.lower_bound <= reaction.upper_bound
-            reaction.upper_bound = reaction.lower_bound - 100
-            assert reaction.lower_bound == reaction.upper_bound
 
     def test_add_metabolites_combine_true(self, core_model):
         test_metabolite = Metabolite('test')
@@ -851,14 +814,14 @@ class TestModel:
         observed_essential_genes = [g.id for g in find_essential_genes(core_model)]
         assert sorted(observed_essential_genes) == sorted(ESSENTIAL_GENES)
         with pytest.raises(OptimizationError):
-            core_model.reactions.Biomass_Ecoli_core_N_LPAREN_w_FSLASH_GAM_RPAREN__Nmet2.lower_bound = 999999.
+            core_model.reactions.Biomass_Ecoli_core_N_LPAREN_w_FSLASH_GAM_RPAREN__Nmet2.bounds = (999999, 999999)
             find_essential_genes(core_model)
 
     def test_essential_reactions(self, core_model):
         observed_essential_reactions = [r.id for r in find_essential_reactions(core_model)]
         assert sorted(observed_essential_reactions) == sorted(ESSENTIAL_REACTIONS)
         with pytest.raises(OptimizationError):
-            core_model.reactions.Biomass_Ecoli_core_N_LPAREN_w_FSLASH_GAM_RPAREN__Nmet2.lower_bound = 999999.
+            core_model.reactions.Biomass_Ecoli_core_N_LPAREN_w_FSLASH_GAM_RPAREN__Nmet2.bounds = (999999, 999999)
             find_essential_reactions(core_model)
 
     def test_essential_metabolites_steady_state(self, core_model):
@@ -867,7 +830,7 @@ class TestModel:
         assert sorted(essential_metabolites_balanced) == sorted(ESSENTIAL_METABOLITES)
 
         with pytest.raises(OptimizationError):
-            core_model.reactions.Biomass_Ecoli_core_N_LPAREN_w_FSLASH_GAM_RPAREN__Nmet2.lower_bound = 999999.
+            core_model.reactions.Biomass_Ecoli_core_N_LPAREN_w_FSLASH_GAM_RPAREN__Nmet2.bounds = (999999, 999999)
             find_essential_metabolites(core_model, force_steady_state=True)
 
     @pytest.mark.xfail(reason='needs some refactoring, uses missing bounds, not allowed by cplex')
@@ -877,7 +840,7 @@ class TestModel:
         assert sorted(essential_metabolites_unbalanced) == sorted(ESSENTIAL_METABOLITES)
 
         with pytest.raises(OptimizationError):
-            core_model.reactions.Biomass_Ecoli_core_N_LPAREN_w_FSLASH_GAM_RPAREN__Nmet2.lower_bound = 999999.
+            core_model.reactions.Biomass_Ecoli_core_N_LPAREN_w_FSLASH_GAM_RPAREN__Nmet2.bounds = (999999, 999999)
             find_essential_metabolites(core_model, force_steady_state=False)
 
     # def test_effective_bounds(self, core_model):


### PR DESCRIPTION
Related to https://github.com/opencobra/cobrapy/issues/793
Merge this after #272 

### Description
Previously in cobrapy, setting a lower bound greater than the upper bound (or viceversa) set both bounds to the input value. This was removed in https://github.com/opencobra/cobrapy/pull/1058 and it will raise an error if the bounds are inconsistent.

### Implementation
* [`.bounds`](https://cobrapy.readthedocs.io/en/latest/autoapi/cobra/core/reaction/index.html#cobra.core.reaction.Reaction.bounds) was used wherever the intention is to fix the reaction flux to a value.
* Some tests that checked the old behavior were removed or changed.