### PR TITLE
fix: set explicitly the auth tokens for twine

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,7 +82,7 @@ jobs:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run:
-        twine upload --skip-existing --non-interactive dist/*
+        twine upload --verbose -u TWINE_USERNAME -p TWINE_PASSWORD --skip-existing --non-interactive dist/*
     - name: Create GitHub release
       uses: actions/create-release@v1
       env:


### PR DESCRIPTION
### Description

Twine upload failed. It might be a) something obscure with the keyring/env variables not being read; or b) the authentication password actually changed.

### Implementation

Tackling a), explicitly set the password and user as command line arguments in the `twine upload` command.