### PR TITLE
Pathway heterologous

### DIFF
--- a/cameo/core/pathway.py
+++ b/cameo/core/pathway.py
@@ -27,7 +27,6 @@ from cobra import Metabolite, Model, Reaction
 from cameo.io import load_model
 
 
-# TODO: Load pathways from SBML and JSON
 # TODO: Define the product
 # TODO: Visualization with ESCHER
 class MetaboliteError(Exception):

--- a/cameo/core/pathway.py
+++ b/cameo/core/pathway.py
@@ -24,6 +24,8 @@ from pandas import DataFrame, read_csv
 from typing import Dict, List
 from cobra import Metabolite, Model, Reaction
 
+from cameo.io import load_model
+
 
 # TODO: Load pathways from SBML and JSON
 # TODO: Define the product
@@ -344,6 +346,30 @@ class Pathway(object):
 
         return DataFrame([[r.build_reaction_string(True), r.lower_bound, r.upper_bound] for r in self.reactions],
                          columns=["equation", "lower_bound", "upper_bound"], index=[r.id for r in self.reactions])
+
+    @classmethod
+    def from_model(
+        cls,
+        path_or_handle,
+        *args,
+        **kwargs
+    ) -> 'Pathway':
+        """Read a pathway from a model.
+        Call cameo.io.load_model and use the same arguments.
+
+        Returns
+        -------
+        Pathway
+            A novel object
+
+        See Also
+        --------
+        cameo.io.load_model
+        Pathway.from_file
+        """
+
+        model = load_model(path_or_handle, *args, **kwargs)
+        return Pathway(model.reactions)
 
     @classmethod
     def from_file(

--- a/cameo/core/pathway.py
+++ b/cameo/core/pathway.py
@@ -11,81 +11,410 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """This module implements a pathway data structure that can be added to a model for example."""
+import csv
+import re
 
+import pandas as pd
+
+from collections import namedtuple
+from io import StringIO
 from functools import partial, reduce
-
-from pandas import DataFrame
-
-from cobra import Metabolite, Reaction
+from pandas import DataFrame, read_csv
+from typing import Dict, List
+from cobra import Metabolite, Model, Reaction
 
 
 # TODO: Load pathways from SBML and JSON
 # TODO: Define the product
 # TODO: Visualization with ESCHER
-class Pathway(object):
+class MetaboliteError(Exception):
+    """Raised when something went wrong when metabolite string is malformated."""
+    def __init__(self, msg):
+        self._msg = msg
+
+    def __str__(self):
+        return 'Metabolite is malformated: {}'.format(self._msg)
+
+
+class EquationError(Exception):
+    """Raised when something went wrong when equation string is malformated."""
+    def __init__(self, msg, equation=''):
+        self._msg = msg
+        self._equation = equation
+
+    def __str__(self):
+        return 'Equation is malformated: {}\n{}'.format(self._msg, self._equation)
+
+
+class PathwayFileError(Exception):
+    """Raised when something went wrong when pathway file is malformated."""
+    def __init__(self, msg):
+        self._msg = msg
+
+    def __str__(self):
+        return 'Pathway file is malformated: {}'.format(self._msg)
+
+
+class Equation(object):
     """
-    Representation of a pathway (a set of reactions)
+    Representation of an equation (a set of metabolites)
 
     Attributes
     ----------
 
-    reactions: list o Reaction
-        The list of reactions in the pathway.
+    stoichiometry: dict of Metabolite, coefficient
 
     """
 
-    def __init__(self, reactions, *args, **kwargs):
+    ReArrow = r'\s*[-=]+>\s*'
+    Token = namedtuple('Token', ['kind', 'value', 'group', 'target'])
+
+    def __init__(
+        self,
+        stochiometry: Dict[Metabolite, float],
+        *args,
+        **kwargs
+    ) -> None:
+        """Initialize an Equation.
+
+        Parameters
+        ----------
+        stochiometry: dict
+            A dictionary of:
+            - key: cobra.Metabolite
+            - value: int
+
+        Returns
+        -------
+        None
+        """
+        super(Equation, self).__init__(*args, **kwargs)
+        self.stochiometry = stochiometry
+
+    @staticmethod
+    def contains_arrow(
+        segment: str
+    ) -> bool:
+        """Check if a string contains an arrow defined to represent an Equation.
+
+        Parameters
+        ----------
+        segment: str
+            A string to check
+
+        Returns
+        -------
+        bool
+        """
+        if re.search(Equation.ReArrow, segment):
+            return True
+        return False
+
+    @staticmethod
+    def tokenize(
+        segment: str
+    ) -> 'Equation.Token':
+        """Parse a String to return differents tokens describing Metabolite & coefficient \
+        in the same order of the String.
+
+        Parameters
+        ----------
+        segment: str
+            A string to parse
+
+        Returns
+        -------
+        TokenEquation
+            namedtuple: kind(COEFF|MET), value(int|cobra.Metabolite), group(product|reactant), target(bool)
+        """
+        token_specification = [
+            ('ARROW', Equation.ReArrow),
+            ('COEFFSEP', r'[\*]{1}'),
+            ('MET', r'(#{1}[\d\w\+\-\s]+#?){3,4}'),
+            ('COEFF', r'\-?(\d+)'),
+            ('AND', r'[\+]{1}'),
+            ('SKIP', r'[ \t]+'),
+            ('END', r'\Z')
+        ]
+        tok_regex = '|'.join('(?P<%s>%s)' % pair for pair in token_specification)
+
+        is_product, is_target = False, False
+        next_met = False
+        for mo in re.finditer(tok_regex, segment):
+            kind = mo.lastgroup
+            value = mo.group()
+            if kind == 'ARROW':
+                is_product = True
+            elif kind == 'AND':
+                continue
+            elif kind == 'COEFF' and not next_met:
+                value = int(value)
+            elif kind == 'COEFFSEP':
+                next_met = True
+                continue
+            elif kind == 'MET' and next_met:
+                values = value.split('#')
+                values = [x for x in values if x != '']
+                if len(values) < 3 or len(values) > 4:
+                    raise MetaboliteError(
+                        'When a metabolite is provided, it needs to be \
+                        formated as #<name>#<id>#<compartement_id>#[<target>#]'
+                    )
+                elif len(values) == 4:
+                    m = re.search(r'target', values[3], flags=re.I)
+                    if m is None:
+                        raise MetaboliteError('When four # is filled, a target keyword is attempted')
+                    else:
+                        is_target = True
+                value = Metabolite(
+                    id=values[1],
+                    name=values[0],
+                    compartment=values[2]
+                )
+                next_met = False
+            elif kind == 'SKIP':
+                continue
+            elif kind == 'END':
+                continue
+            group = 'product' if is_product else 'reactant'
+            token = Equation.Token(
+                kind,
+                value,
+                group,
+                is_target
+            )
+            is_target = False
+
+            yield token
+
+    @staticmethod
+    def from_string(
+        equation: str
+    ) -> 'Equation':
+        """Construct an Equation object from a string.
+
+        Parameters
+        ----------
+        equation: str
+            An equation to parse.
+            Must have a specific syntax:
+              - contains an arrow like '->' to separate product/reactant
+              - describe product and reactant like:
+                '<coefficient:int> * <metabolite:str>'
+              - product and reactant are combined with '+' operator
+              - a metabolite is described like:
+                '#<id:str>#<name:str>#<compartment_id:str#'
+                Optionaly, you could specify if it's a target by adding to the current metabolite:
+                'target#'
+
+        Returns
+        -------
+        Equation
+            A novel object.
+        """
+        stoichiometry = {}
+
+        nb_coef, nb_met = 0, 0
+        nb_target, nb_arrow = 0, 0
+        coef = None
+        for token in Equation.tokenize(equation):
+            if token.kind == 'ARROW':
+                nb_arrow += 1
+            elif token.kind == 'COEFF':
+                nb_coef += 1
+                if token.group == 'product':
+                    coef = abs(float(token.value))
+                else:
+                    coef = -abs(float(token.value))
+            elif token.kind == 'MET':
+                nb_met += 1
+                if coef is None:
+                    raise MetaboliteError('A coefficient must be set with each metabolite')
+                stoichiometry[token.value] = coef
+                coef = None
+                if token.target:
+                    nb_target += 1
+
+        if nb_arrow != 1:
+            raise EquationError('An arrow must be indicated in equation string or must be surrounded by spaces')
+        elif nb_coef != nb_met:
+            raise EquationError('The number of coefficient must be the same as the number of metabolites')
+        elif nb_target > 1:
+            raise EquationError('A maximum of one metabolite target must be indicated')
+
+        return Equation(stoichiometry)
+
+    def to_string(self) -> str:
+        """Represent an Equation to a string.
+
+        Returns
+        -------
+        String
+            A representation of an Equation.
+        """
+
+        products = {m: v for m, v in self.stochiometry.items() if v > 0}
+        reactants = {m: v for m, v in self.stochiometry.items() if v < 0}
+
+        products = " + ".join(['%s * #%s#%s#%s#' % (int(v), m.name, m.id, m.compartment) for m, v in products.items()])
+        reactants = " + ".join(['%s * #%s#%s#%s#' % (-int(v), m.name, m.id, m.compartment) for m, v in reactants.items()])
+        return reactants + " <=> " + products
+
+    def to_reaction(
+        self,
+        identifier: str,
+        name: str,
+        lower: float = 0.0,
+        upper: float = 1000.0,
+        comments: str = ''
+    ) -> Reaction:
+        """Construct an Equation object from a string.
+
+        Parameters
+        ----------
+        identifier: str
+            An id for the reaction
+        name: str
+            A name for the reaction
+        lower: float
+            A lower bound for the reaction (Default: 0.0)
+        upper: float
+            An upper bound for the reaction (Default: 1000.0)
+        comments: str
+            A comment to associate for the reaction (Default: '')
+
+        Returns
+        -------
+        Reaction
+            A novel object.
+        """
+        reaction = Reaction(identifier)
+        reaction.id = identifier
+        reaction.name = name
+        reaction.add_metabolites(self.stochiometry)
+        reaction.upper_bound = float(upper)
+        reaction.lower_bound = float(lower)
+        reaction.notes["pathway_note"] = comments
+        return reaction
+
+
+class Pathway(object):
+    """Representation of a pathway (a set of reactions)
+
+    Attributes
+    ----------
+    reactions: list of cobra.Reaction
+        The list of reactions in the pathway.
+    """
+
+    FileHeader = ['id', 'name', 'equation', 'lower_bound', 'upper_bound', 'comments']
+
+    def __init__(
+        self,
+        reactions: List[Reaction],
+        *args,
+        **kwargs
+    ) -> None:
+        """Initialize a Pathway.
+
+        Attributes
+        ----------
+        reactions: list of cobra.Reaction
+            The list of reactions in the pathway.
+
+        Returns
+        -------
+        None
+        """
         super(Pathway, self).__init__(*args, **kwargs)
         self.reactions = reactions
 
     @property
-    def data_frame(self):
+    def data_frame(self) -> DataFrame:
+        """Represents the reactions with a dataframe.
+
+        Returns
+        -------
+        pd.DataFrame
+            A dataframe with :
+              - row: a reaction
+              - col: equation, lower bound, upper bound
+        """
+
         return DataFrame([[r.build_reaction_string(True), r.lower_bound, r.upper_bound] for r in self.reactions],
                          columns=["equation", "lower_bound", "upper_bound"], index=[r.id for r in self.reactions])
 
     @classmethod
-    def from_file(cls, file_path, sep="\t"):
-        """
-        Read a pathway from a file.
+    def from_file(
+        cls,
+        file_path: str,
+        sep: str = 'auto'
+    ) -> 'Pathway':
+        """Read a pathway from a file.
 
         The file format is:
-        reaction_id<sep>equation<sep>lower_limit<sep>upper_limit<sep>name<sep>comments\n
+        id<sep>name<sep>equation<sep>lower_bound<sep>upper_bound<sep>comments\n
+        This header must be provided in the file.
 
         The equation is defined by:
-        coefficient * substrate_name#substrate_id + ... <=> coefficient * product_name#product_id
+        coefficient * #substrate_name#substrate_id#substrate_compartment# + ... => \
+            coefficient * #product_name#product_id#product_compartment#
 
         Parameters
         ----------
         file_path: str
             The path to the file containing the pathway
         sep: str
-            The separator between elements in the file (default: "\t")
+            The separator between elements in the file (default: "auto")
 
         Returns
         -------
         Pathway
-
+            A novel object
         """
-        reactions = []
-        metabolites = {}
-        with open(file_path, "r") as pathway:
-            for line in pathway:
-                if line.startswith("#"):
-                    continue
-                line = line.strip("\n")
+        # Sniff if file is well formated.
+        if sep == 'auto':
+            with open(file_path) as fid:
+                dialect = csv.Sniffer().sniff(fid.readline())
+            sep = dialect.delimiter
 
-                identifier, equation, lower, upper, name, comments = line.split(sep)
-                stoichiometry = _parse_equation(equation, metabolites)
-                reaction = _build_reaction(identifier, stoichiometry, float(upper), float(lower), name, comments)
-                reactions.append(reaction)
+        # Check header.
+        lines = []
+        with open(file_path) as fid:
+            csv_reader = csv.reader(fid, delimiter=sep)
+            lines = [x for x in csv_reader if not x[0].startswith('#')]
+
+        if len(lines) < 1:
+            raise PathwayFileError('You must provide at lear one entry except the header.')
+        if len(lines[0]) != 6:
+            raise PathwayFileError('Too much fields are in the file, you must respect the format attempted.')
+
+        header = lines[0]
+        if Equation.contains_arrow(sep.join(header)):
+            raise PathwayFileError('Pathway file must contain an header.')
+
+        # Buffering.
+        lines = [sep.join(x) for x in lines]
+        lines = '\n'.join(lines)
+
+        # Load.
+        df = read_csv(StringIO(lines), sep=sep, na_values='', skiprows=1, names=Pathway.FileHeader)
+
+        # Build reactions
+        def _build_reaction(x):
+            eq = Equation.from_string(x['equation'])
+            return eq.to_reaction(x['id'], x['name'], x['lower_bound'], x['upper_bound'], x['comments'])
+        reactions = [x for x in df.apply(_build_reaction, axis=1)]
 
         return cls(reactions)
 
-    def to_file(self, file_path, sep="\t"):
-        """
-        Writes the pathway to a file.
+    def to_file(
+        self,
+        file_path: str,
+        sep: str = '\t'
+    ) -> None:
+        """Writes the pathway to a file.
 
         Parameters
         ----------
@@ -94,82 +423,51 @@ class Pathway(object):
         sep: str
             The separator between elements in the file (default: "\t")
 
+        Returns
+        -------
+        None
+
         See Also
         --------
         Pathway.from_file
-
         """
-        with open(file_path, "w") as output_file:
+        with open(file_path, 'w') as output_file:
+            output_file.write(sep.join(Pathway.FileHeader) + '\n')
             for reaction in self.reactions:
-                equation = _build_equation(reaction.metabolites)
+                equation = Equation(reaction.metabolites)
+                comments = reaction.notes.get('pathway_note', '')
+                if pd.isna(comments):
+                    comments = ''
                 output_file.write(sep.join(map(str, [
                     reaction.id,
-                    equation,
+                    equation.to_string(),
                     reaction.lower_bound,
                     reaction.upper_bound,
                     reaction.name,
-                    reaction.notes.get("pathway_note", "")
-                ])) + "\n")
+                    comments
+                ])) + '\n')
 
-    def plug_model(self, model):
-        """
-        Plug the pathway to a model.
+    def plug_model(
+        self,
+        model: Model
+    ) -> Model:
+        """Plug the pathway to a model.
 
-        Metabolites are matched in the model by id. For metabolites with no ID in the model, an exchange reaction
-        is added to the model
+        Metabolites are matched in the model by id.\
+        For metabolites with no ID in the model, an exchange reaction is added to the model
 
         Parameters
         ----------
         model: cobra.Model
             The model to plug in the pathway
 
+        Returns
+        -------
+        cobra.Model
+            A model with pathway reactions added.
         """
         model.add_reactions(self.reactions)
         metabolites = set(reduce(lambda x, y: x + y, [list(r.metabolites.keys()) for r in self.reactions], []))
         exchanges = [model.add_boundary(m) for m in metabolites if len(m.reactions) == 1]
         for exchange in exchanges:
-            exchange.lower_bound = 0
-
-
-def _build_reaction(identifier, stoichiometry, upper, lower, name, comments):
-    reaction = Reaction(identifier)
-    reaction.id = identifier
-    reaction.name = name
-    reaction.add_metabolites(stoichiometry)
-    reaction.upper_bound = upper
-    reaction.lower_bound = lower
-    reaction.notes["pathway_note"] = comments
-    return reaction
-
-
-def _parse_equation(equation, metabolites):
-    stoichiometry = {}
-    reactants, products = equation.split(" <=> ")
-    for reactant in reactants.split(" + "):
-        coeff, metabolite = reactant.split(" * ")
-        name, metabolite_id = metabolite.split("#")
-        if metabolite_id in metabolites:
-            met = metabolites[metabolite_id]
-        else:
-            metabolites[metabolite_id] = met = Metabolite(id=metabolite_id, name=name)
-        stoichiometry[met] = -float(coeff)
-
-    for product in products.split(" + "):
-        coeff, metabolite = product.split(" * ")
-        name, metabolite_id = metabolite.split("#")
-        if metabolite_id in metabolites:
-            met = metabolites[metabolite_id]
-        else:
-            metabolites[metabolite_id] = met = Metabolite(id=metabolite_id, name=name)
-        stoichiometry[met] = float(coeff)
-
-    return stoichiometry
-
-
-def _build_equation(stoichiometry):
-    products = {m: v for m, v in stoichiometry.items() if v > 0}
-    reactants = {m: v for m, v in stoichiometry.items() if v < 0}
-
-    products = " + ".join(["%f * %s#%s" % (v, m.name, m.id) for m, v in products.items()])
-    reactants = " + ".join(["%f * %s#%s" % (-v, m.name, m.id) for m, v in reactants.items()])
-    return reactants + " <=> " + products
+            exchange.lower_bound = 0.0

--- a/tests/data/1-butanol.csv
+++ b/tests/data/1-butanol.csv
@@ -1,7 +1,7 @@
 id,name,equation,lower_bound,upper_bound,comments
-ButCoaDeh,Butyryl-CoA dehydrogenase,1 * #Crotonoyl-CoA#b2coa_c#c# + 1 * #NADH#nadh_c#c# + 1 * #H#h_c#c# <=> 1 * #Butyryl-CoA#btcoa_c#c# + 1 * #NAD#nad_c#c#,1000.0,1000.0,metanetx.reaction:undefined
-ButanalDeh,Butanal dehydrogenase,1 * #Butyryl-CoA#btcoa_c#c# + 1 * #NADH#nadh_c#c# + 1 * #H+#h_c#c# <=> 1 * #Butanal#btal_c#c# + 1 * #NAD#nad_c#c#,1000.0,1000.0,metanetx.reaction:MNXR95755
-ButanolDeh,Butanol dehydrogenase,1 * #Butanal#btal_c#c# + 1 * #NADH#nadh_c#c# + 1 * #H+#h_c#c#=> 1 * #1-Butanol#1btol_c#c# + 1 * #NAD#nad_c#c#,1000.0,1000.0
-ButOlTrP,1-Butanol transporter (periplasm),1 *#1-Butanol#1btol_c#c# + 1* #H+#h_c#c# -> 1*#1-Butanol#1btol_p#p# + 1 * #H+#h_p#p#,1000.0,1000.0
-ButOlTrE,1-Butanol transporter (extracellular),1 * #1-Butanol#1btol_p#p# --> 1 * #1-Butanol#1btol_e#e#,1000.0,1000.0
-ButOlTrEx,1-Butanol transporter (exchange),1 * #1-Butanol#1btol_e#e#target# -->,1000.0,2000.0
+ButCoaDeh,Butyryl-CoA dehydrogenase,1 * #Crotonoyl-CoA#b2coa_c#c# + 1 * #Nicotinamide adenine dinucleotide - reduced#nadh_c#c# + 1 * #H+#h_c#c# <=> 1 * #Gamma-butyrobetainyl-CoA#btcoa_c#c# + 1 * #Deamino-NAD+#nad_c#c#,0.0,1000.0,metanetx.reaction:undefined
+ButanalDeh,Butanal dehydrogenase,1 * #Gamma-butyrobetainyl-CoA#btcoa_c#c# + 1 * #Nicotinamide adenine dinucleotide - reduced#nadh_c#c# + 1 * #H+#h_c#c# <=> 1 * #Butanal C4H8O#btal_c#c# + 1 * #Deamino-NAD+#nad_c#c#,0.0,1000.0,metanetx.reaction:MNXR95755
+ButanolDeh,Butanol dehydrogenase,1 * #Butanal C4H8O#btal_c#c# + 1 * #Nicotinamide adenine dinucleotide - reduced#nadh_c#c# + 1 * #H+#h_c#c#=> 1 * #butan1ol#1btol_c#c# + 1 * #Deamino-NAD+#nad_c#c#,0.0,1000.0
+ButOlTrP,1-Butanol transporter (periplasm),1 *#butan1ol#1btol_c#c# + 1* #H+#h_c#c# -> 1*#butan1ol#1btol_p#p# + 1 * #H+#h_p#p#,0.0,1000.0
+ButOlTrE,1-Butanol transporter (extracellular),1 * #butan1ol#1btol_p#p# --> 1 * #butan1ol#1btol_e#e#,0.0,1000.0
+EX_1btol_e,1-Butanol transporter (exchange),1 * #butan1ol#1btol_e#e#target# <=>,-1000.0,1000.0

--- a/tests/data/1-butanol.csv
+++ b/tests/data/1-butanol.csv
@@ -1,0 +1,7 @@
+id,name,equation,lower_bound,upper_bound,comments
+ButCoaDeh,Butyryl-CoA dehydrogenase,1 * #Crotonoyl-CoA#b2coa_c#c# + 1 * #NADH#nadh_c#c# + 1 * #H#h_c#c# <=> 1 * #Butyryl-CoA#btcoa_c#c# + 1 * #NAD#nad_c#c#,1000.0,1000.0,metanetx.reaction:undefined
+ButanalDeh,Butanal dehydrogenase,1 * #Butyryl-CoA#btcoa_c#c# + 1 * #NADH#nadh_c#c# + 1 * #H+#h_c#c# <=> 1 * #Butanal#btal_c#c# + 1 * #NAD#nad_c#c#,1000.0,1000.0,metanetx.reaction:MNXR95755
+ButanolDeh,Butanol dehydrogenase,1 * #Butanal#btal_c#c# + 1 * #NADH#nadh_c#c# + 1 * #H+#h_c#c#=> 1 * #1-Butanol#1btol_c#c# + 1 * #NAD#nad_c#c#,1000.0,1000.0
+ButOlTrP,1-Butanol transporter (periplasm),1 *#1-Butanol#1btol_c#c# + 1* #H+#h_c#c# -> 1*#1-Butanol#1btol_p#p# + 1 * #H+#h_p#p#,1000.0,1000.0
+ButOlTrE,1-Butanol transporter (extracellular),1 * #1-Butanol#1btol_p#p# --> 1 * #1-Butanol#1btol_e#e#,1000.0,1000.0
+ButOlTrEx,1-Butanol transporter (exchange),1 * #1-Butanol#1btol_e#e#target# -->,1000.0,2000.0

--- a/tests/data/1-butanol.xml
+++ b/tests/data/1-butanol.xml
@@ -1,0 +1,496 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:groups="http://www.sbml.org/sbml/level3/version1/groups/version1" xmlns:fbc="http://www.sbml.org/sbml/level3/version1/fbc/version2" level="3" version="1" groups:required="false" fbc:required="false">
+  <model metaid="meta_butanol" id="butanol" fbc:strict="true">
+    <listOfUnitDefinitions>
+      <unitDefinition id="mmol_per_gDW_per_hr">
+        <listOfUnits>
+          <unit kind="mole" exponent="1" scale="-3" multiplier="1"/>
+          <unit kind="gram" exponent="-1" scale="0" multiplier="1"/>
+          <unit kind="second" exponent="-1" scale="0" multiplier="3600"/>
+        </listOfUnits>
+      </unitDefinition>
+    </listOfUnitDefinitions>
+    <fbc:listOfObjectives fbc:activeObjective="obj">
+      <fbc:objective fbc:id="obj" fbc:type="maximize">
+        <fbc:listOfFluxObjectives>
+          <fbc:fluxObjective fbc:reaction="R_EX_1btol_e" fbc:coefficient="0.5"/>
+        </fbc:listOfFluxObjectives>
+      </fbc:objective>
+    </fbc:listOfObjectives>
+    <listOfCompartments>
+      <compartment id="c" name="cytosol" constant="true"/>
+      <compartment id="p" name="periplasm" constant="true"/>
+      <compartment id="e" name="extracellular space" constant="true"/>
+    </listOfCompartments>
+    <listOfSpecies>
+      <species metaid="meta_M_co2_e" sboTerm="SBO:0000247" id="M_co2_e" name="CO2 CO2" compartment="e" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="CO2">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_co2_e">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/co2"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CARBON-DIOXIDE"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:23011"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:3283"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:48829"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:16526"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:13283"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:13285"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:13284"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:13282"/>
+                  <rdf:li rdf:resource="https://identifiers.org/envipath/650babc9-9d68-4b73-9332-11972ca26f7b/compound/2ec3da94-5f50-4525-81b1-5607c5c7a3d3"/>
+                  <rdf:li rdf:resource="https://identifiers.org/envipath/32de3cf4-e3e6-4168-956e-32fa5ddb0ce1/compound/05f60af4-0a3f-4ead-9a29-33bb0f123379"/>
+                  <rdf:li rdf:resource="https://identifiers.org/hmdb/HMDB01967"/>
+                  <rdf:li rdf:resource="https://identifiers.org/inchi_key/CURLTUGMZLYLDI-UHFFFAOYSA-N"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00011"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.drug/D00004"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM13"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/29376"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/5668565"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/189480"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/1132345"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/113528"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/1237009"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/159751"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/389536"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/159942"/>
+                  <rdf:li rdf:resource="https://identifiers.org/sabiork/1266"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00011"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_glc__D_e" sboTerm="SBO:0000247" id="M_glc__D_e" name="D-Glucose" compartment="e" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C6H12O6">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_glc__D_e">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/glc__D"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:Glucopyranose"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:12965"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:20999"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:4167"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:17634"/>
+                  <rdf:li rdf:resource="https://identifiers.org/hmdb/HMDB00122"/>
+                  <rdf:li rdf:resource="https://identifiers.org/hmdb/HMDB06564"/>
+                  <rdf:li rdf:resource="https://identifiers.org/inchi_key/WQZGKKKJIJFFOK-GASJEMHNSA-N"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00031"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.drug/D00009"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM41"/>
+                  <rdf:li rdf:resource="https://identifiers.org/sabiork/1406"/>
+                  <rdf:li rdf:resource="https://identifiers.org/sabiork/1407"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd26821"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00027"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_b2coa_c" sboTerm="SBO:0000247" id="M_b2coa_c" name="Crotonoyl-CoA" compartment="c" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-4" fbc:chemicalFormula="C25H36N7O17P3S">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_b2coa_c">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/b2coa"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CROTONYL-COA"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:3928"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:11531"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:15473"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:36926"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:57332"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:23408"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:14031"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:14032"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:13921"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:41612"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:58669"/>
+                  <rdf:li rdf:resource="https://identifiers.org/envipath/32de3cf4-e3e6-4168-956e-32fa5ddb0ce1/compound/c0e5f008-6d8b-4b94-a265-03d19ff197f4"/>
+                  <rdf:li rdf:resource="https://identifiers.org/hmdb/HMDB62466"/>
+                  <rdf:li rdf:resource="https://identifiers.org/hmdb/HMDB02009"/>
+                  <rdf:li rdf:resource="https://identifiers.org/hmdb/HMDB59627"/>
+                  <rdf:li rdf:resource="https://identifiers.org/inchi_key/KFWWCMJSYSSPSK-PAXLJYGASA-J"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00877"/>
+                  <rdf:li rdf:resource="https://identifiers.org/lipidmaps/LMFA07050307"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM214"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/71045"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/77313"/>
+                  <rdf:li rdf:resource="https://identifiers.org/sabiork/2174"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00650"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_btcoa_c" sboTerm="SBO:0000247" id="M_btcoa_c" name="Gamma-butyrobetainyl-CoA" compartment="c" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-3" fbc:chemicalFormula="C28H46N8O17P3S">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_btcoa_c">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/btcoa"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:GAMMA-BUTYROBETAINYL-COA"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:61513"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:61517"/>
+                  <rdf:li rdf:resource="https://identifiers.org/inchi_key/QAMRRBGWSPTAEJ-SVHODSNWSA-K"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C20749"/>
+                  <rdf:li rdf:resource="https://identifiers.org/lipidmaps/LMFA07050321"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM5762"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd15412"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_btal_c" sboTerm="SBO:0000247" id="M_btal_c" name="Butanal C4H8O" compartment="c" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C4H8O">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_btal_c">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/btal"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:BUTANAL"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:22938"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:3233"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:15743"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:13923"/>
+                  <rdf:li rdf:resource="https://identifiers.org/envipath/650babc9-9d68-4b73-9332-11972ca26f7b/compound/242f8a4e-2a91-4c5f-a129-d044d115b969"/>
+                  <rdf:li rdf:resource="https://identifiers.org/hmdb/HMDB03543"/>
+                  <rdf:li rdf:resource="https://identifiers.org/inchi_key/ZTQSAGDEMFDKMZ-UHFFFAOYSA-N"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C01412"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1017"/>
+                  <rdf:li rdf:resource="https://identifiers.org/sabiork/2281"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd01011"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_nad_c" sboTerm="SBO:0000247" id="M_nad_c" name="Deamino-NAD+" compartment="c" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C21H24N6O15P2">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_nad_c">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/nad"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:DEAMIDO-NAD"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:14104"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:58437"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:14103"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:4340"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:14105"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:18304"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:23567"/>
+                  <rdf:li rdf:resource="https://identifiers.org/hmdb/HMDB01179"/>
+                  <rdf:li rdf:resource="https://identifiers.org/inchi_key/SENPVEZBRZQVST-HISDBWNOSA-L"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00857"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM309"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/8938090"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/200499"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/197256"/>
+                  <rdf:li rdf:resource="https://identifiers.org/sabiork/1349"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00638"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_nadh_c" sboTerm="SBO:0000247" id="M_nadh_c" name="Nicotinamide adenine dinucleotide - reduced" compartment="c" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C21H27N7O14P2">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_nadh_c">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/nadh"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:NADH"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:13395"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:21902"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:7423"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:44216"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:57945"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:16908"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:13396"/>
+                  <rdf:li rdf:resource="https://identifiers.org/hmdb/HMDB01487"/>
+                  <rdf:li rdf:resource="https://identifiers.org/inchi_key/BOPGDPNILDQYTO-NNYOXOHSSA-L"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00004"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM10"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/192305"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/73473"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/29362"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/194697"/>
+                  <rdf:li rdf:resource="https://identifiers.org/sabiork/38"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00004"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_h_c" sboTerm="SBO:0000247" id="M_h_c" name="H+" compartment="c" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="1" fbc:chemicalFormula="H">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_h_c">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/h"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:PROTON"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:5584"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:13357"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:15378"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:10744"/>
+                  <rdf:li rdf:resource="https://identifiers.org/hmdb/HMDB59597"/>
+                  <rdf:li rdf:resource="https://identifiers.org/inchi_key/GPRLSGONYQIRFK-UHFFFAOYSA-N"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00080"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/2000349"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/425978"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/74722"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/428040"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/427899"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/428548"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/156540"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/70106"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/425969"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/1132304"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/5668577"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/1470067"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/163953"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/193465"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/113529"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/351626"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/425999"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/194688"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/374900"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/2872447"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/372511"/>
+                  <rdf:li rdf:resource="https://identifiers.org/sabiork/39"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00067"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_h_e" sboTerm="SBO:0000247" id="M_h_e" name="H+" compartment="e" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="1" fbc:chemicalFormula="H">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_h_e">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/h"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:PROTON"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:5584"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:13357"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:15378"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:10744"/>
+                  <rdf:li rdf:resource="https://identifiers.org/hmdb/HMDB59597"/>
+                  <rdf:li rdf:resource="https://identifiers.org/inchi_key/GPRLSGONYQIRFK-UHFFFAOYSA-N"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00080"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/2000349"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/425978"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/74722"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/428040"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/427899"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/428548"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/156540"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/70106"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/425969"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/1132304"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/5668577"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/1470067"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/163953"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/193465"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/113529"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/351626"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/425999"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/194688"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/374900"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/2872447"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/372511"/>
+                  <rdf:li rdf:resource="https://identifiers.org/sabiork/39"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00067"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_h_p" sboTerm="SBO:0000247" id="M_h_p" name="H+" compartment="p" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="1" fbc:chemicalFormula="H">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_h_p">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/h"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:PROTON"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:5584"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:13357"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:15378"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:10744"/>
+                  <rdf:li rdf:resource="https://identifiers.org/hmdb/HMDB59597"/>
+                  <rdf:li rdf:resource="https://identifiers.org/inchi_key/GPRLSGONYQIRFK-UHFFFAOYSA-N"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00080"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/2000349"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/425978"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/74722"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/428040"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/427899"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/428548"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/156540"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/70106"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/425969"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/1132304"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/5668577"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/1470067"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/163953"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/193465"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/113529"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/351626"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/425999"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/194688"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/374900"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/2872447"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome.compound/372511"/>
+                  <rdf:li rdf:resource="https://identifiers.org/sabiork/39"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00067"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_1btol_c" id="M_1btol_c" name="butan1ol" compartment="c" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:chemicalFormula="C4H10O">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_1btol_c">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:22936"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_1btol_p" id="M_1btol_p" name="butan1ol" compartment="p" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:chemicalFormula="C4H10O">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_1btol_p">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:22936"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_1btol_e" id="M_1btol_e" name="butan1ol" compartment="e" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:chemicalFormula="C4H10O">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_1btol_e">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:22936"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+    </listOfSpecies>
+    <listOfParameters>
+      <parameter constant="true" id="cobra_default_lb" name="cobra default - lb" sboTerm="SBO:0000626" units="mmol_per_gDW_per_hr" value="-1000"/>
+      <parameter constant="true" id="cobra_default_ub" name="cobra default - ub" sboTerm="SBO:0000626" units="mmol_per_gDW_per_hr" value="1000"/>
+      <parameter constant="true" id="cobra_0_bound" name="cobra 0 - bound" sboTerm="SBO:0000625" units="mmol_per_gDW_per_hr" value="0"/>
+    </listOfParameters>
+    <listOfReactions>
+      <reaction metaid="meta_R_EX_1btol_e" sboTerm="SBO:0000627" id="R_EX_1btol_e" name="butan1ol exchange" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
+        <listOfReactants>
+          <speciesReference species="M_1btol_e" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+      </reaction>
+      <reaction id="R_ButCoaDeh" name="Butyryl-CoA dehydrogenase" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
+        <listOfReactants>
+          <speciesReference species="M_b2coa_c" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_nadh_c" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_h_c" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_btcoa_c" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_nad_c" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+      </reaction>
+      <reaction id="R_ButanalDeh" name="Butanal dehydrogenase" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
+        <listOfReactants>
+          <speciesReference species="M_btcoa_c" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_nadh_c" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_h_c" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_btal_c" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_nad_c" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+      </reaction>
+      <reaction id="R_ButanolDeh" name="Butanol dehydrogenase" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
+        <listOfReactants>
+          <speciesReference species="M_btal_c" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_nadh_c" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_h_c" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_1btol_c" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_nad_c" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+      </reaction>
+      <reaction id="R_ButOlTrP" name="1-Butanol transporter (periplasm)" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
+        <listOfReactants>
+          <speciesReference species="M_1btol_c" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_h_c" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_1btol_p" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_h_p" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+      </reaction>
+      <reaction id="R_ButOlTrE" name="1-Butanol transporter (extracellular)" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
+        <listOfReactants>
+          <speciesReference species="M_1btol_p" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_1btol_e" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+      </reaction>
+    </listOfReactions>
+    <groups:listOfGroups>
+      <groups:group metaid="meta_rp_pathway" groups:id="rp_pathway" groups:kind="collection">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:BRSynth rdf:about="meta_rp_pathway">
+              <brsynth:brsynth xmlns:brsynth="http://brsynth.eu"/>
+            </rdf:BRSynth>
+          </rdf:RDF>
+        </annotation>
+        <groups:listOfMembers>
+          <groups:member groups:idRef="R_ButCoaDeh"/>
+          <groups:member groups:idRef="R_ButanalDeh"/>
+          <groups:member groups:idRef="R_ButanolDeh"/>
+          <groups:member groups:idRef="R_ButOlTrP"/>
+          <groups:member groups:idRef="R_ButOlTrE"/>
+          <groups:member groups:idRef="R_EX_1btol_e"/>
+        </groups:listOfMembers>
+      </groups:group>
+    </groups:listOfGroups>
+  </model>
+</sbml>

--- a/tests/test_pathway.py
+++ b/tests/test_pathway.py
@@ -14,6 +14,11 @@ def but_csv(data_directory):
     return os.path.join(data_directory, '1-butanol.csv')
 
 
+@pytest.fixture(scope="module")
+def but_xml(data_directory):
+    return os.path.join(data_directory, '1-butanol.xml')
+
+
 @pytest.fixture(scope='module')
 def but_df(but_csv):
     return pd.read_csv(but_csv)
@@ -29,22 +34,22 @@ def but_met():
     )
     mets['nadh_c'] = Metabolite(
         id='nadh_c',
-        name='NADH',
+        name='Nicotinamide adenine dinucleotide - reduced',
         compartment='c'
     )
     mets['h_c'] = Metabolite(
         id='h_c',
-        name='H',
+        name='H+',
         compartment='c'
     )
     mets['btcoa_c'] = Metabolite(
         id='btcoa_c',
-        name='Butyryl-CoA',
+        name='Gamma-butyrobetainyl-CoA',
         compartment='c'
     )
     mets['nad_c'] = Metabolite(
         id='nad_c',
-        name='NAD',
+        name='Deamino-NAD+',
         compartment='c'
     )
     return mets
@@ -144,7 +149,7 @@ class TestEquation:
         )
 
         # Theorical value
-        th = Reaction(id='ButCoaDeh', name='Butyryl-CoA dehydrogenase', lower_bound=1000, upper_bound=1000)
+        th = Reaction(id='ButCoaDeh', name='Butyryl-CoA dehydrogenase', lower_bound=0, upper_bound=1000)
         th.add_metabolites(but_st)
         th.notes["pathway_note"] = 'metanetx.reaction:undefined'
 
@@ -156,6 +161,14 @@ class TestEquation:
 
 
 class TestPathway:
+    def test_from_model(self, but_xml, but_csv):
+        pathway_model = Pathway.from_model(but_xml)
+        pathway_file = Pathway.from_file(but_csv)
+
+        df_model = pathway_model.data_frame.sort_index()
+        df_file = pathway_file.data_frame.sort_index()
+        assert df_model.equals(df_file)
+
     def test_from_file(self, but_csv):
         pathway = Pathway.from_file(but_csv)
 

--- a/tests/test_pathway.py
+++ b/tests/test_pathway.py
@@ -1,0 +1,181 @@
+import filecmp
+import os
+import pytest
+import tempfile
+
+import pandas as pd
+
+from cobra import Metabolite, Reaction
+from cameo.core.pathway import Equation, Pathway
+
+
+@pytest.fixture(scope="module")
+def but_csv(data_directory):
+    return os.path.join(data_directory, '1-butanol.csv')
+
+
+@pytest.fixture(scope='module')
+def but_df(but_csv):
+    return pd.read_csv(but_csv)
+
+
+@pytest.fixture(scope='module')
+def but_met():
+    mets = {}
+    mets['b2coa_c'] = Metabolite(
+        id='b2coa_c',
+        name='Crotonoyl-CoA',
+        compartment='c'
+    )
+    mets['nadh_c'] = Metabolite(
+        id='nadh_c',
+        name='NADH',
+        compartment='c'
+    )
+    mets['h_c'] = Metabolite(
+        id='h_c',
+        name='H',
+        compartment='c'
+    )
+    mets['btcoa_c'] = Metabolite(
+        id='btcoa_c',
+        name='Butyryl-CoA',
+        compartment='c'
+    )
+    mets['nad_c'] = Metabolite(
+        id='nad_c',
+        name='NAD',
+        compartment='c'
+    )
+    return mets
+
+
+
+@pytest.fixture(scope='module')
+def but_st(but_met):
+    st = {}
+    st[but_met['b2coa_c']] = -1
+    st[but_met['nadh_c']] = -1
+    st[but_met['h_c']] = -1
+    st[but_met['btcoa_c']] = 1
+    st[but_met['nad_c']] = 1
+    return st
+
+
+class TestEquation:
+    def test_contains_arrow(self):
+        segments = []
+        segments.append(('aa=>aa', True))
+        segments.append(('aa->a', True))
+        segments.append(('aa->', True))
+        segments.append(('aa ->a', True))
+        segments.append(('aa -> ', True))
+        segments.append(('-> a', True))
+        segments.append(('a>a', False))
+        segments.append(('a', False))
+        segments.append(('-a', False))
+        segments.append(('', False))
+        for tes in segments:
+            assert Equation.contains_arrow(tes[0]) == tes[1]
+
+    def test_tokenize(self, but_df, but_met):
+        equations = but_df['equation'].to_list()
+        tokens = [x for x in Equation.tokenize(equations[0])]
+
+        # Theorical list
+        ths = []
+        ths.append(Equation.Token(kind='COEFF', value=1, group='reactant', target=False))
+        ths.append(Equation.Token(kind='MET', value=but_met['b2coa_c'], group='reactant', target=False))
+        ths.append(Equation.Token(kind='COEFF', value=1, group='reactant', target=False))
+        ths.append(Equation.Token(kind='MET', value=but_met['nadh_c'], group='reactant', target=False))
+        ths.append(Equation.Token(kind='COEFF', value=1, group='reactant', target=False))
+        ths.append(Equation.Token(kind='MET', value=but_met['h_c'], group='reactant', target=False))
+        ths.append(Equation.Token(kind='ARROW', value='=> ', group='product', target=False))
+        ths.append(Equation.Token(kind='COEFF', value=1, group='product', target=False))
+        ths.append(Equation.Token(kind='MET', value=but_met['btcoa_c'], group='product', target=False))
+        ths.append(Equation.Token(kind='COEFF', value=1, group='product', target=False))
+        ths.append(Equation.Token(kind='MET', value=but_met['nad_c'], group='product', target=False))
+
+        assert len(tokens) == len(ths)
+        for token, th in zip(tokens, ths):
+            # cobra.Metabolite does not implement yet __eq__()
+            if isinstance(token.value, Metabolite) and isinstance(th.value, Metabolite):
+                assert token.value.id == th.value.id
+                assert token.value.name == th.value.name
+                assert token.value.compartment == th.value.compartment
+            else:
+                assert token == th
+
+    def test_from_string(self, but_df, but_met):
+        equations = but_df['equation'].to_list()
+        equation = Equation.from_string(equations[0])
+        stochiometry = {}
+        for k, v in equation.stochiometry.items():
+            stochiometry[k.id] = v
+
+        # Theorical value
+        ths = {}
+        ths['b2coa_c'] = -1.0
+        ths['nadh_c'] = -1.0
+        ths['h_c'] = -1.0
+        ths['btcoa_c'] = 1.0
+        ths['nad_c'] = 1.0
+
+        assert stochiometry == ths
+
+    def test_to_string(self, but_df, but_st):
+        equation = Equation(but_st)
+
+        # Theorical value
+        equations = but_df['equation'].to_list()
+
+        assert equation.to_string() == equations[0]
+
+    def test_to_reaction(self, but_df, but_st):
+        sequation = but_df.loc[0]
+        equation = Equation.from_string(sequation['equation'])
+
+        reaction = equation.to_reaction(
+            identifier=sequation['id'],
+            name=sequation['name'],
+            lower=sequation['lower_bound'],
+            upper=sequation['upper_bound'],
+            comments=sequation['comments']
+        )
+
+        # Theorical value
+        th = Reaction(id='ButCoaDeh', name='Butyryl-CoA dehydrogenase', lower_bound=1000, upper_bound=1000)
+        th.add_metabolites(but_st)
+        th.notes["pathway_note"] = 'metanetx.reaction:undefined'
+
+        # cobra.Reaction does not implement yet __eq__()
+        assert reaction.id == th.id
+        assert reaction.name == th.name
+        assert reaction.bounds == th.bounds
+        assert reaction.notes == th.notes
+
+
+class TestPathway:
+    def test_from_file(self, but_csv):
+        pathway = Pathway.from_file(but_csv)
+
+        assert len(pathway.reactions) == 6
+
+    def test_to_file(self, but_csv, but_df):
+        pathway = Pathway.from_file(but_csv)
+        tmp = ''
+        with tempfile.NamedTemporaryFile(delete=False) as fod:
+            tmp = fod.name
+            pathway.to_file(tmp, sep=",")
+            lines = fod.read().splitlines()
+
+        assert len(lines) == but_df.shape[0] + 1
+
+        os.remove(fod.name)
+
+    def test_plug_model(self, salmonella, but_csv):
+        pathway = Pathway.from_file(but_csv)
+
+        assert len([x for x in salmonella.reactions if x.id == 'ButOlTrE']) == 0
+        pathway.plug_model(salmonella)
+        assert len([x for x in salmonella.reactions if x.id == 'ButOlTrE']) == 1


### PR DESCRIPTION
Several improvements:
- Change format for Pathway file: header mandatory, order header fields, metabolite format
- Takes into account the compartment of metabolites
- Let to have no product in equation to add exchange reaction
- Use regex to be more permissive when parsing file
- Add load_model()